### PR TITLE
Fixed memory leak that happened when calling apply

### DIFF
--- a/freenect2/__init__.py
+++ b/freenect2/__init__.py
@@ -346,7 +346,8 @@ class Frame(object):
         attributes are initialised.
 
         """
-        return Frame(lib.freenect2_frame_create(width, height, bytes_per_pixel))
+        frame_ref = lib.freenect2_frame_create(width, height, bytes_per_pixel)
+        return Frame(ffi.gc(frame_ref, lib.freenect2_frame_dispose))
 
     def to_image(self):
         """Convert the Frame to a PIL :py:class:`Image` instance."""


### PR DESCRIPTION
Registration.apply caused a memory leak because Frame.create did not associate freenect2_frame_dispose to the garbage collector.

A simple line fixes the problem. I tested this on another machine, but I do not have the Kinect here, so I cannot test the file right now, but should work.